### PR TITLE
Add EnTT CMake consumer test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,11 +21,25 @@ requirements:
     - ninja  # [not win]
 
 test:
+  requires:
+    - {{ compiler("c") }}
+    - {{ compiler("cxx") }}
+    - {{ stdlib("c") }}
+    - cmake
+    - ninja
+  files:
+    - test_package
   commands:
     - test -d ${PREFIX}/include/entt  # [unix]
     - test -f ${PREFIX}/lib/EnTT/cmake/EnTTTargets.cmake  # [unix]
+    - cmake -S test_package -B test_build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${PREFIX}  # [unix]
+    - cmake --build test_build --config Release  # [unix]
+    - ./test_build/entt_consumer  # [unix]
     - if not exist %PREFIX%\\Library\\include\\entt exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\EnTT\cmake\\EnTTTargets.cmake exit 1  # [win]
+    - cmake -S test_package -B test_build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX%  # [win]
+    - cmake --build test_build --config Release  # [win]
+    - test_build\\entt_consumer.exe  # [win]
 
 about:
   home: https://github.com/skypjack/entt/wiki

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
 
 test:
   requires:
-    - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - {{ stdlib("c") }}
     - cmake

--- a/recipe/test_package/CMakeLists.txt
+++ b/recipe/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(entt_consumer LANGUAGES CXX)
+
+find_package(EnTT CONFIG REQUIRED)
+
+add_executable(entt_consumer test_package.cpp)
+target_compile_features(entt_consumer PRIVATE cxx_std_17)
+target_link_libraries(entt_consumer PRIVATE EnTT::EnTT)

--- a/recipe/test_package/test_package.cpp
+++ b/recipe/test_package/test_package.cpp
@@ -1,0 +1,32 @@
+#include <cassert>
+
+#include <entt/entity/registry.hpp>
+
+struct position {
+    float x;
+    float y;
+};
+
+struct velocity {
+    float dx;
+    float dy;
+};
+
+int main() {
+    entt::registry registry;
+    const auto entity = registry.create();
+
+    registry.emplace<position>(entity, 1.0F, 2.0F);
+    registry.emplace<velocity>(entity, 0.5F, -1.0F);
+
+    registry.view<position, const velocity>().each([](auto, position &pos, const velocity &vel) {
+        pos.x += vel.dx;
+        pos.y += vel.dy;
+    });
+
+    const auto &pos = registry.get<position>(entity);
+    assert(pos.x == 1.5F);
+    assert(pos.y == 1.0F);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a downstream CMake consumer test that uses `find_package(EnTT CONFIG REQUIRED)`
- compile and run a small EnTT registry example through the installed `EnTT::EnTT` target
- keep the existing recipe format and generated files unchanged

## Validation
- `git diff --check`
- `conda-smithy recipe-lint --conda-forge recipe`